### PR TITLE
Fix/postgres port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ go.work.sum
 
 # env file
 .env
+
+# IDE Files
+.idea/
+.idea
+.vscode/
+.vscode
+*.iml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,10 @@ services:
       POSTGRES_PASSWORD: admin
       POSTGRES_DB: artio_db
     ports:
-      - "5432:5432"
+      - "5000:5432"
     volumes:
-      - artio_data:/var/lib/postgresql/data
+      - artio_insight_data:/var/lib/postgresql/data
 
 volumes:
-  artio_data:
+  artio_insight_data:
   grafana_data:


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file to update the PostgreSQL service configuration. The most important changes include modifying the port mapping and renaming the volume for PostgreSQL data storage.

Changes to PostgreSQL service configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L22-R27): Changed the PostgreSQL port mapping from `5432:5432` to `5000:5432`.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L22-R27): Renamed the PostgreSQL data volume from `artio_data` to `artio_insight_data`.