### PR TITLE
fix(docker): adding restart policy to the containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GF_PASSWORD}
     ports:
       - ${GF_PORT}:3000
+    restart: always
     volumes:
       - artio_insight_gf_data:/var/lib/grafana
 
@@ -20,6 +21,7 @@ services:
       POSTGRES_DB: ${DB_NAME}
     ports:
       - ${DB_PORT}:5432
+    restart: always
     volumes:
       - artio_insight_db_data:/var/lib/postgresql/data
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `docker-compose.yml` file, adding a `restart: always` policy to ensure services automatically restart in case of failure or system reboot.

Key changes:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R9): Added `restart: always` to the Grafana service to improve reliability.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R24): Added `restart: always` to the PostgreSQL service to ensure consistent availability.